### PR TITLE
Introduce "Train Phase Interface"

### DIFF
--- a/docs/rebuild_html_doc.sh
+++ b/docs/rebuild_html_doc.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 make clean && make html

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -81,3 +81,25 @@ omitted.
 .. autoclass:: CosineAnnealingLR
 
 .. autoclass:: ReduceLROnPlateau
+
+Policies
+--------
+
+.. automodule:: pytoune.framework.callbacks.policies
+
+.. autoclass:: Phase
+
+.. autoclass:: OptimizerPolicy
+
+.. autofunction:: linspace
+
+.. autofunction:: cosinespace
+
+High Level Policies
+~~~~~~~~~~~~~~~~~~~
+
+Ready to use policies.
+
+.. autofunction:: one_cycle_phases
+
+.. autofunction:: sgdr_phases

--- a/examples/policy_cifar_example.ipynb
+++ b/examples/policy_cifar_example.ipynb
@@ -1,0 +1,245 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train CIFAR with the `policy` module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device(\"cuda:0\" if torch.cuda.is_available() else \"cpu\")\n",
+    "device"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Load the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision import transforms\n",
+    "\n",
+    "_mean = [0.485, 0.456, 0.406]\n",
+    "_std = [0.229, 0.224, 0.225]\n",
+    "\n",
+    "\n",
+    "train_transform = transforms.Compose([\n",
+    "    transforms.RandomHorizontalFlip(),\n",
+    "    transforms.ColorJitter(.3, .3, .3),\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize(_mean, _std),\n",
+    "])\n",
+    "val_transform = transforms.Compose([\n",
+    "    transforms.ToTensor(),\n",
+    "    transforms.Normalize(_mean, _std),\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.datasets as datasets\n",
+    "\n",
+    "root = \"data\"\n",
+    "train_ds = datasets.CIFAR10(root, train=True, transform=train_transform, download=True)\n",
+    "val_ds = datasets.CIFAR10(root, train=False, transform=val_transform, download=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "\n",
+    "BATCH_SIZE = 1024\n",
+    "\n",
+    "train_dl = DataLoader(\n",
+    "    train_ds,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    shuffle=True,\n",
+    "    num_workers=8,\n",
+    ")\n",
+    "val_dl = DataLoader(\n",
+    "    val_ds,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    shuffle=False,\n",
+    "    num_workers=8,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# The model\n",
+    "We'll train a simple resnet18 network.\n",
+    "This takes a while without GPU but is pretty quick with GPU."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from torchvision.models import resnet18\n",
+    "import torch.nn as nn\n",
+    "import torch.optim as optim\n",
+    "\n",
+    "\n",
+    "def get_module():\n",
+    "    model = resnet18(pretrained=False)\n",
+    "    model.avgpool = nn.AdaptiveAvgPool2d(1)\n",
+    "    model.fc = nn.Linear(512, 10)\n",
+    "    return model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = 5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training without the `policies` module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pytorch_module = get_module().to(device)\n",
+    "criterion = nn.CrossEntropyLoss()\n",
+    "optimizer = optim.SGD(pytorch_module.parameters(), lr=0.01)\n",
+    "\n",
+    "model = Model(\n",
+    "    pytorch_module,\n",
+    "    optimizer,\n",
+    "    criterion,\n",
+    "    metrics=[\"acc\"],\n",
+    ")\n",
+    "model = model.to(device)\n",
+    "\n",
+    "history = model.fit_generator(\n",
+    "    train_dl,\n",
+    "    val_dl,\n",
+    "    epochs=epochs,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training with the `policies` module"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "steps_per_epoch = len(train_dl)\n",
+    "steps_per_epoch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import OptimizerPolicy, one_cycle_phases\n",
+    "\n",
+    "\n",
+    "pytorch_module = get_module().to(device)\n",
+    "criterion = nn.CrossEntropyLoss()\n",
+    "optimizer = optim.SGD(pytorch_module.parameters(), lr=0.01)\n",
+    "\n",
+    "model = Model(\n",
+    "    pytorch_module,\n",
+    "    optimizer,\n",
+    "    criterion,\n",
+    "    metrics=[\"acc\"],\n",
+    ")\n",
+    "model = model.to(device)\n",
+    "\n",
+    "policy = OptimizerPolicy(\n",
+    "    one_cycle_phases(epochs * steps_per_epoch, lr=(0.01, 0.1, 0.008)),\n",
+    ")\n",
+    "history = model.fit_generator(\n",
+    "    train_dl,\n",
+    "    val_dl,\n",
+    "    epochs=epochs,\n",
+    "    callbacks=[policy],\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/policy_interface.ipynb
+++ b/examples/policy_interface.ipynb
@@ -1,0 +1,290 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interface of the `policy` module\n",
+    "\n",
+    "The `policy` modules gives you fine grained control over the training process.\n",
+    "This notebooks demonstrates how the `policy` module works and how you can create your own policies.\n",
+    "\n",
+    "Note: make sure matplotlib is installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parameter spaces and phases\n",
+    "Parameter spaces like `linspace` and `cosinespace` are the basic building blocks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import linspace, cosinespace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can define the space and iterate over them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = linspace(1, 0, 3)\n",
+    "for i in space:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "space = cosinespace(1, 0, 5)\n",
+    "for i in space:\n",
+    "    print(i)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use the space and create a phase with them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import Phase\n",
+    "\n",
+    "phase = Phase(lr=linspace(0, 1, 3))\n",
+    "\n",
+    "# and iterate\n",
+    "for d in phase:\n",
+    "    print(d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also visualize your phase:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase.plot(\"lr\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Phases can have multiple parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phase = Phase(\n",
+    "    lr=linspace(0, 1, 10),\n",
+    "    momentum=cosinespace(.99, .9, 10),\n",
+    ")\n",
+    "\n",
+    "phase.plot(\"lr\");\n",
+    "phase.plot(\"momentum\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize different phases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "steps = 100\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "# Constant value\n",
+    "Phase(lr=linspace(.7, .7, steps)).plot(ax=ax)\n",
+    "# Linear\n",
+    "Phase(lr=linspace(0, 1, steps)).plot(ax=ax)\n",
+    "# Cosine\n",
+    "Phase(lr=cosinespace(1, 0, steps)).plot(ax=ax);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize multiple parameters in one phase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "steps = 100\n",
+    "phase = Phase(lr=linspace(1, 0.5, steps), momentum=cosinespace(.8, 1, steps))\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 3))\n",
+    "phase.plot(\"lr\", ax=axes[0])\n",
+    "phase.plot(\"momentum\", ax=axes[1]);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Build complex policies from basic phases\n",
+    "You can build complex optimizer policies by chaining phases together:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import OptimizerPolicy\n",
+    "\n",
+    "policy = OptimizerPolicy([\n",
+    "    Phase(lr=linspace(0, 1, 100)),\n",
+    "    Phase(lr=cosinespace(1, 0, 200)),\n",
+    "    Phase(lr=linspace(0, .5, 100)),\n",
+    "    Phase(lr=linspace(.5, .1, 300)),\n",
+    "])\n",
+    "\n",
+    "policy.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use already defined complex policies\n",
+    "\n",
+    "It's easy to build your own policies, but PyToune contains some pre-defined phases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import sgdr_phases\n",
+    "\n",
+    "# build them manually\n",
+    "policy = OptimizerPolicy([\n",
+    "    Phase(lr=cosinespace(1, 0, 200)),\n",
+    "    Phase(lr=cosinespace(1, 0, 400)),\n",
+    "    Phase(lr=cosinespace(1, 0, 800)),\n",
+    "])\n",
+    "policy.plot()\n",
+    "\n",
+    "# or use the pre-defined one\n",
+    "policy = OptimizerPolicy(sgdr_phases(base_cycle_length=200, cycles=3, cycle_mult=2))\n",
+    "policy.plot();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pre-defined ones are just a list phases:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sgdr_phases(base_cycle_length=200, cycles=3, cycle_mult=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is the one-cycle policy:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pytoune.framework import one_cycle_phases\n",
+    "\n",
+    "tp = OptimizerPolicy(one_cycle_phases(steps=500))\n",
+    "tp.plot(\"lr\")\n",
+    "tp.plot(\"momentum\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pytoune/framework/callbacks/__init__.py
+++ b/pytoune/framework/callbacks/__init__.py
@@ -10,3 +10,4 @@ from .lr_scheduler import *
 from .terminate_on_nan import *
 from .best_model_restore import *
 from .clip_grad import *
+from .policies import *

--- a/pytoune/framework/callbacks/policies.py
+++ b/pytoune/framework/callbacks/policies.py
@@ -1,0 +1,312 @@
+"""
+The ``policies`` module is an alternative way to configure your training process.
+It gives you fine grained control over the process.
+
+The training is divided into phases with the ``Phase`` class.
+A ``Phase`` contains parameter spaces
+(e.g. learning rate, or momentum, or both)
+for the optimizer.
+You chain ``Phase`` instances by passing them to the ``OptimizerPolicy``
+``OptimizerPolicy`` is a ``Callback`` that uses the phasese,
+steps through them, and sets the parameters of the optimizer.
+
+"""
+# pylint: disable=inconsistent-return-statements
+###############################################################################
+import contextlib
+from collections import OrderedDict
+from math import cos, pi
+from itertools import islice, chain
+from typing import Dict, List, Tuple
+
+from pytoune.framework.callbacks.callbacks import Callback
+
+
+###############################################################################
+# Lazy parameter spaces
+# A space is just an iterable
+class linspace:
+    """
+    A lazy linear parameter space that goes from ``start`` to ``end`` in
+    ``steps`` steps.
+
+    Args:
+        start: the start point.
+        end: the end point.
+        steps: the number of steps between start and end.
+
+    Example:
+        >>> list(linspace(0, 1, 3))
+        [0.0, 0.5, 1.0]
+    """
+
+    def __init__(self, start: float, end: float, steps: int):
+        self.start = start
+        self.end = end
+        self.steps = steps
+
+    def _progress(self, i):
+        return i / (self.steps - 1)
+
+    def __iter__(self):
+        return (
+            self.start + self._progress(i) * (self.end - self.start)
+            for i in range(self.steps)
+        )
+
+
+class cosinespace:
+    """
+    A lazy cosine parameter space that goes from ``start`` to ``end`` in
+    ``steps`` steps.
+
+    Args:
+        start: the start point.
+        end: the end point.
+        steps: the number of steps between start and end.
+
+    Example:
+        >>> list(cosinespace(0, 1, 3))
+        [0.0, 0.5, 1.0]
+    """
+
+    def __init__(self, start, end, steps):
+        self.start = start
+        self.end = end
+        self.steps = steps
+
+    def _progress(self, i):
+        return i / (self.steps - 1)
+
+    def __iter__(self):
+        return (
+            self.end + (self.start - self.end) * (1 + cos(self._progress(i) * pi)) / 2
+            for i in range(self.steps)
+        )
+
+
+###############################################################################
+class Phase:
+    """
+    A ``Phase`` defines how to configure an optimizer.
+
+    For each train step it returns a dictionary that contains the configuration
+    for the optimizer.
+
+    Args:
+        lr: a configuration space for the learning rate (optional).
+        momentum: a configuration space for the momentum (optional).
+    """
+
+    def __init__(self, *, lr=None, momentum=None):
+        if lr is None and momentum is None:
+            raise ValueError("You must specify lr and/or momentum.")
+
+        self.configuration = OrderedDict()
+        if lr is not None:
+            self.configuration["lr"] = lr
+        if momentum is not None:
+            self.configuration["momentum"] = momentum
+
+    def __iter__(self):
+        names = list(self.configuration.keys())
+        values = self.configuration.values()
+        for values in zip(*self.configuration.values()):
+            yield {name: value for name, value in zip(names, values)}
+
+    def __repr__(self):
+        return "\n".join(
+            [
+                "Phase:",
+                *[
+                    "    {}: {}".format(name, val)
+                    for name, val in self.configuration.items()
+                ],
+            ]
+        )
+
+    def plot(self, param_name: str = "lr", ax=None):
+        """
+        Plot the phase for the given `param_name`.
+
+        Args:
+            param_name: the name of the parameter to plot (optional)
+            ax: a matplotlib axis to plot on, if given (optional).
+
+        Returns:
+            The matplotlib axis.
+        """
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            print("You must install matplotlib to use the plot functionality.")
+            return
+
+        if ax is None:
+            _fig, ax = plt.subplots()
+
+        ax.plot(list(self.configuration[param_name]))
+        ax.set_xlabel("steps")
+        ax.set_ylabel(param_name)
+        return ax
+
+
+###############################################################################
+# complex policies build from simple phases
+def one_cycle_phases(
+        steps: int,
+        lr: Tuple[float, float] = (0.1, 1),
+        momentum: Tuple[float, float] = (0.95, 0.85),
+        finetune_lr: float = .01,
+        finetune_fraction: float = 0.1,
+    ) -> List[Phase]:
+    """
+    The "one-cycle" policy as described in the paper
+    "Super-Convergence: Very Fast Training of Neural Networks Using Large Learning Rates".
+
+    You might want to read the paper and adjust the parameters.
+
+    Args:
+        steps: the total number of steps to take.
+        lr: tuple for the triangular learning rate (start, middle).
+        momentum: tuple for the triangular momentum (start, middle).
+        finetune_lr: target learning rate for the final finetuning.
+            Should be smaller than `min(lr)`.
+        finetune_fraction: fraction of steps used for the finetuning.
+            Must be between 0 and 1.
+
+    Returns:
+        A list of configured ``Phase`` instances.
+
+    References:
+        "Super-Convergence: Very Fast Training of Neural Networks Using Large Learning Rates"
+            Leslie N. Smith, Nicholay Topin
+            https://arxiv.org/abs/1708.07120
+    """
+    steps_annealing = int(steps * finetune_fraction)
+    steps_up = (steps - steps_annealing) // 2
+    steps_down = steps - steps_annealing - steps_up
+    return [
+        Phase(
+            lr=linspace(lr[0], lr[1], steps_up),
+            momentum=linspace(momentum[0], momentum[1], steps_up),
+        ),
+        Phase(
+            lr=linspace(lr[1], lr[0], steps_down),
+            momentum=linspace(momentum[1], momentum[0], steps_down),
+        ),
+        Phase(
+            lr=linspace(lr[0], finetune_lr, steps_annealing),
+            momentum=linspace(momentum[0], momentum[0], steps_annealing),
+        ),
+    ]
+
+
+def sgdr_phases(
+        base_cycle_length: int,
+        cycles: int,
+        lr: Tuple[float, float] = (1., 0.1),
+        cycle_mult: int = 2,
+    ) -> List[Phase]:
+    """
+    The "SGDR" policy as described in the paper
+    "SGDR: Stochastic Gradient Descent with Warm Restarts".
+
+    Note the total number of steps is calculated like this:
+    `total_steps = sum(base_cycle_length * (cycle_mult ** i) for i in range(cycles))`
+
+    You might want to read the paper and adjust the parameters.
+
+    Args:
+        base_cycle_length: number of steps for the first cycle.
+        cycles: the number of repetitions.
+        lr: tuple for the learning rate for one cycle: (start, end).
+        cycle_mult: multiply the last cycle length with this every cycle.
+            The length of a cycle grows exponentially.
+
+    Returns:
+        A list of configured ``Phase`` instances.
+
+    References:
+        "SGDR: Stochastic Gradient Descent with Warm Restarts"
+            Ilya Loshchilov, Frank Hutter
+            https://arxiv.org/abs/1608.03983
+    """
+    steps = [base_cycle_length * (cycle_mult ** i) for i in range(cycles)]
+    return [Phase(lr=cosinespace(lr[0], lr[1], step)) for step in steps]
+
+
+###############################################################################
+class OptimizerPolicy(Callback):
+    """
+    Combine different ``Phase`` instances in an ``OptimizerPolicy``
+    and execute the policies in a row.
+
+    Args:
+        phases: A list of ``Phase`` instances.
+        initial_step: The step to start the policy in. Used for restarting.
+    """
+
+    def __init__(self, phases: List, *, initial_step: int = 0):
+        super().__init__()
+        self.phases = phases
+        self.current_step = initial_step
+        self.phases_iter = iter(self)
+
+    def on_batch_begin(self, batch, logs):
+        # Don't do anything when we run out of phases.
+        with contextlib.suppress(StopIteration):
+            spec = next(self.phases_iter)
+            self._update_optimizer(spec)
+
+    def __iter__(self):
+        space_iter = islice(chain.from_iterable(self.phases), self.current_step, None)
+        for param_dict in space_iter:
+            self.current_step += 1
+            yield param_dict
+
+    def all_steps(self) -> List[Dict]:
+        """
+        Return the list of dictionaries of configurations for all steps.
+
+        This does not advance the current_step count.
+
+        Returns:
+            A list of dictionaries of all the parameters for each step.
+        """
+        return chain.from_iterable(self.phases)
+
+    def __repr__(self):
+        return "OptimizerPolicy:\n    phases: {}\n    current_step: {}".format(
+            self.current_step, len(self.phases)
+        )
+
+    def _update_optimizer(self, param_dict: Dict):
+        for param_name, param_value in param_dict.items():
+            for group in self.model.optimizer.param_groups:
+                group[param_name] = param_value
+
+    def plot(self, param_name: str = "lr", ax=None):
+        """
+        Visualize all `Phase`s of this `OptimizerPolicy`.
+
+        Args:
+            param_name: the name of the parameter to plot (optional)
+            ax: a matplotlib axis to plot on, if given (optional).
+
+        Returns:
+            The matplotlib axis.
+        """
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            print("You must install matplotlib to use the plot functionality.")
+            return
+
+        if ax is None:
+            _fig, ax = plt.subplots()
+
+        values = [step[param_name] for step in self.all_steps()]
+        ax.plot(values)
+        ax.set_ylabel(param_name)
+        ax.set_xlabel("steps")

--- a/tests/framework/callbacks/test_policies.py
+++ b/tests/framework/callbacks/test_policies.py
@@ -1,0 +1,155 @@
+import unittest
+
+from pytoune.framework.callbacks.policies import linspace, cosinespace
+from pytoune.framework.callbacks.policies import Phase, OptimizerPolicy
+from pytoune.framework.callbacks.policies import one_cycle_phases, sgdr_phases
+
+
+class TestSpaces(unittest.TestCase):
+    def assert_space(self, space, expected):
+        for val, exp in zip(space, expected):
+            self.assertAlmostEqual(val, exp, places=3)
+
+    def test_linspace_const(self):
+        self.assert_space(linspace(0, 0, 3), [0, 0, 0])
+
+    def test_linspace_increasing(self):
+        self.assert_space(linspace(0, 1, 3), [0, .5, 1])
+
+    def test_linspace_decreasing(self):
+        self.assert_space(linspace(1, 0, 3), [1, .5, 0])
+
+    def test_linspace_with_many_values(self):
+        self.assert_space(linspace(0, 1, 6), [0, .2, .4, .6, .8, 1])
+
+    def test_cosinespace_const(self):
+        self.assert_space(cosinespace(0, 0, 2), [0, 0])
+
+    def test_cosinespace_increasing(self):
+        self.assert_space(cosinespace(0, 1, 2), [0, 1])
+        self.assert_space(cosinespace(0, 1, 3), [0, .5, 1])
+
+    def test_cosinespace_decreasing(self):
+        self.assert_space(cosinespace(1, 0, 2), [1, 0])
+        self.assert_space(cosinespace(1, 0, 3), [1, .5, 0])
+
+    def test_cosinespace_with_many_values(self):
+        self.assert_space(cosinespace(0, 1, 5), [0, .1464, .5, .8535, 1])
+        self.assert_space(cosinespace(1, 0, 5), [1, .8535, .5, .1464, 0])
+
+    def test_space_has_desired_legth(self):
+        for space_fn in [linspace, cosinespace]:
+            space = list(space_fn(2, 1, 3))
+            assert len(space) == 3
+            with self.assertRaises(IndexError):
+                space[4]  # pylint: disable=pointless-statement
+
+
+class TestPhase(unittest.TestCase):
+    def test_init_raises_without_lr_or_momentum(self):
+        with self.assertRaises(ValueError):
+            Phase(lr=None, momentum=None)
+        with self.assertRaises(ValueError):
+            Phase()
+
+    def test_phase_with_only_one_parameter_set(self):
+        for param_name in ["lr", "momentum"]:
+            steps = 3
+            phase = Phase(**{param_name: linspace(1, 0, steps)})
+            for params in phase:
+                self.assertIsInstance(params, dict)
+                self.assertTrue(param_name in params)
+                self.assertEqual(len(params), 1)
+                self.assertTrue(0 <= params[param_name] <= 1)
+
+    def test_phase_with_two_parameters(self):
+        steps = 4
+        phase = Phase(lr=linspace(1, 0, steps), momentum=cosinespace(.8, 1, steps))
+        self.assertEqual(len(list(phase)), steps)
+        for params in phase:
+            self.assertEqual(len(params), 2)
+
+            self.assertTrue("lr" in params)
+            self.assertTrue(0 <= params["lr"] <= 1)
+
+            self.assertTrue("momentum" in params)
+            self.assertTrue(.8 <= params["momentum"] <= 1)
+
+
+class TestOptimizerPolicy(unittest.TestCase):
+    def setUp(self):
+        steps = 2
+        phases = [Phase(lr=linspace(1, 1, steps)), Phase(lr=linspace(0, 0, steps))]
+        self.policy = OptimizerPolicy(phases)
+
+    def test_basic_iteration(self):
+        policy_iter = iter(self.policy)
+        self.assertEqual(next(policy_iter), {"lr": 1})
+        self.assertEqual(next(policy_iter), {"lr": 1})
+
+        self.assertEqual(next(policy_iter), {"lr": 0})
+        self.assertEqual(next(policy_iter), {"lr": 0})
+
+        with self.assertRaises(StopIteration):
+            next(policy_iter)
+
+
+class TestOptimizerPolicyRestart(unittest.TestCase):
+    def setUp(self):
+        steps = 2
+        phases = [
+            Phase(lr=linspace(0, 0, steps)),
+            Phase(lr=linspace(1, 1, steps)),
+            Phase(lr=linspace(2, 2, steps)),
+        ]
+        self.policy = OptimizerPolicy(phases=phases, initial_step=3)
+
+    def test_starts_at_correct_position(self):
+        policy_iter = iter(self.policy)
+        # The first three steps are ignored
+        # assert next(policy_iter) == {"lr": 0}
+        # assert next(policy_iter) == {"lr": 0}
+        # assert next(policy_iter) == {"lr": 1}
+        assert next(policy_iter) == {"lr": 1}
+        assert next(policy_iter) == {"lr": 2}
+        assert next(policy_iter) == {"lr": 2}
+
+        with self.assertRaises(StopIteration):
+            next(policy_iter)
+
+
+class TestOneCycle(unittest.TestCase):
+    def test_length(self):
+        policy = OptimizerPolicy(one_cycle_phases(100))
+        self.assertEqual(len(list(policy.all_steps())), 100)
+
+        policy = OptimizerPolicy(one_cycle_phases(99))
+        self.assertEqual(len(list(policy.all_steps())), 99)
+
+
+class TestSGDR(unittest.TestCase):
+    def test_length_with_cycle_mult_one(self):
+        policy = OptimizerPolicy(sgdr_phases(10, 1, cycle_mult=1))
+        self.assertEqual(len(list(policy.all_steps())), 10)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 2, cycle_mult=1))
+        self.assertEqual(len(list(policy.all_steps())), 20)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 10, cycle_mult=1))
+        self.assertEqual(len(list(policy.all_steps())), 100)
+
+    def test_length_with_higher_cycle_mult(self):
+        policy = OptimizerPolicy(sgdr_phases(10, 1, cycle_mult=2))
+        self.assertEqual(len(list(policy.all_steps())), 10)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 2, cycle_mult=2))
+        self.assertEqual(len(list(policy.all_steps())), 30)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 3, cycle_mult=2))
+        self.assertEqual(len(list(policy.all_steps())), 70)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 1, cycle_mult=3))
+        self.assertEqual(len(list(policy.all_steps())), 10)
+
+        policy = OptimizerPolicy(sgdr_phases(10, 2, cycle_mult=3))
+        self.assertEqual(len(list(policy.all_steps())), 40)


### PR DESCRIPTION
This PR is going to introduce a fastai-like "train phase interface" and create the foundation for more complex and fine grained control over the training process.

The PR addresses and closes #15.

This PR adds the following
- Parameter spaces: `LinSpace` and `CosineSpace` lazily generate values in the specified domain.
- The `TrainPhase` class uses the parameter spaces and specifies how to configure the optimizer in each step. It return a dict of optimizer parameters.
- The `TrainPolicy` combines different `TrainPhase`s and updates the optimizer according to the parameters returned by the `TrainPolicy`s.

**TODO**
- [x] first implementation
- [x] tweak implementation
- [x] Store the state of the `TrainPolicy` and make it restartable
- [x] add "one cycle" policy
- [x] add "sgdr" policy
- [x] fully test everything (and switch from pytest back to UnitTest)
  - [x] spaces
  - [x] TrainPhase
  - [x] TrainPolicy
  - [x] integration test
- [x] docs
  - [x] write docstrings
  - [x] add to sphinx
  - [x] clean up sphinx warnings
- [x] add references to the papers
- [x] create a example notebook
- [x] clean up commit history


**Possible extensions**
- Different optimizers could be set for each phase
- More policies
- Set different learning rates for different part of the network