### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ num_classes = 5
 
 num_train_samples = 800
 train_x = np.random.randn(num_train_samples, num_features).astype('float32')
-train_y = np.random.randint(num_classes, size=num_train_samples)
+train_y = np.random.randint(num_classes, size=num_train_samples).astype('int64')
+)
 
 num_valid_samples = 200
 valid_x = np.random.randn(num_valid_samples, num_features).astype('float32')
-valid_y = np.random.randint(num_classes, size=num_valid_samples)
+valid_y = np.random.randint(num_classes, size=num_valid_samples).astype('int64')
 
 num_test_samples = 200
 test_x = np.random.randn(num_test_samples, num_features).astype('float32')
-test_y = np.random.randint(num_classes, size=num_test_samples)
+test_y = np.random.randint(num_classes, size=num_test_samples).astype('int64')
 ```
 
 Create yourself a [PyTorch](https://pytorch.org/docs/master/nn.html) network;


### PR DESCRIPTION
The basic example as written produces an error with recently installed versions of python and pytorch (python 3.7.1 and pytorch 1.0.1), because the numpy *_y arrays are created as type int32 which get converted to torch IntTensors, while the cross-entropy loss of pytorch expects LongTensor. This fixes the error by creating the numpy arrays with type int64. See https://pste.eu/p/2N5f.html.